### PR TITLE
refactor: replace chatter API call with in-memory viewer list

### DIFF
--- a/TwitchToolkit/TwitchToolkit.Commands.ModCommands/RefreshViewers.cs
+++ b/TwitchToolkit/TwitchToolkit.Commands.ModCommands/RefreshViewers.cs
@@ -8,7 +8,6 @@ public class RefreshViewers : CommandDriver
 {
 	public override void RunCommand(ITwitchMessage twitchMessage)
 	{
-		WebRequest_BeginGetResponse.Main("https://tmi.twitch.tv/group/user/" + ToolkitCoreSettings.channel_username.ToLower() + "/chatters", Viewers.SaveUsernamesFromJsonResponse);
-		TwitchWrapper.SendChatMessage("@" + twitchMessage.Username + " viewers have been reshed.");
-	}
+               TwitchWrapper.SendChatMessage("This command is deprecated.");
+       }
 }

--- a/TwitchToolkit/TwitchToolkit.Incidents/IncidentWorker_Raid.cs
+++ b/TwitchToolkit/TwitchToolkit.Incidents/IncidentWorker_Raid.cs
@@ -78,7 +78,7 @@ public abstract class IncidentWorker_Raid : IncidentWorker_PawnsArrive
 		parms.points = AdjustedRaidPoints(parms.points, parms.raidArrivalMode, parms.raidStrategy, parms.faction, combat);
 		PawnGroupMakerParms defaultPawnGroupMakerParms = IncidentParmsUtility.GetDefaultPawnGroupMakerParms(combat, parms, false);
 		List<Pawn> list = PawnGroupMakerUtility.GeneratePawns(defaultPawnGroupMakerParms, true).ToList();
-		List<string> viewernames = Viewers.ParseViewersFromJsonAndFindActiveViewers();
+		List<string> viewernames = Viewers.All.Select(v => v.username).ToList();
 		if (list.Count > 0 && viewernames != null)
 		{
 			int count = 0;

--- a/TwitchToolkit/TwitchToolkit.Windows/Window_Trackers.cs
+++ b/TwitchToolkit/TwitchToolkit.Windows/Window_Trackers.cs
@@ -146,7 +146,7 @@ public class Window_Trackers : Window
 
 	private void UpdateTrackerStats()
 	{
-		viewerCount = ((Viewers.jsonallviewers != null) ? Viewers.ParseViewersFromJsonAndFindActiveViewers().Count : 0);
+		viewerCount = ((Viewers.All != null) ? Viewers.All.Count : 0);
 		cooldownsByTypeEnabled = ToolkitSettings.MaxEvents;
 		Store_Component component = Current.Game.GetComponent<Store_Component>();
 		goodEventsInLog = component.KarmaTypesInLogOf(KarmaType.Good);

--- a/TwitchToolkit/TwitchToolkit.Windows/Window_ViewerEditProp.cs
+++ b/TwitchToolkit/TwitchToolkit.Windows/Window_ViewerEditProp.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Verse;
 
@@ -29,7 +30,6 @@ public class Window_ViewerEditProp : Window
 		this.action = action;
 		this.prop = prop;
 		base.doCloseButton = true;
-		Viewers.RefreshViewers();
 		if (viewer == null)
 		{
 			allViewers = true;
@@ -91,7 +91,7 @@ public class Window_ViewerEditProp : Window
 		{
 			if (action == EditPropsActions.Give)
 			{
-				foreach (string viewer in Viewers.ParseViewersFromJsonAndFindActiveViewers())
+				foreach (string viewer in Viewers.All.Select(v => v.username).ToList())
 				{
 					viewersToUpdate.Add(Viewers.GetViewer(viewer));
 				}

--- a/TwitchToolkit/TwitchToolkit.Windows/Window_Viewers.cs
+++ b/TwitchToolkit/TwitchToolkit.Windows/Window_Viewers.cs
@@ -29,7 +29,6 @@ public class Window_Viewers : Window
 	public Window_Viewers()
 	{
 		Helper.Log("constructing viewers window");
-		Viewers.RefreshViewers();
 		if (Current.Game != null)
 		{
 			component = Current.Game.GetComponent<GameComponentPawns>();

--- a/TwitchToolkit/TwitchToolkit.csproj
+++ b/TwitchToolkit/TwitchToolkit.csproj
@@ -35,19 +35,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="ToolkitCore">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\ToolkitCore\Assemblies\ToolkitCore.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\294100\3013874066\v1.5\Assemblies\ToolkitCore.dll</HintPath>
     </Reference>
     <Reference Include="TwitchLib.Client">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\ToolkitCore\Assemblies\TwitchLib.Client.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\294100\3013874066\v1.5\Assemblies\TwitchLib.Client.dll</HintPath>
     </Reference>
     <Reference Include="TwitchLib.Client.Enums">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\ToolkitCore\Assemblies\TwitchLib.Client.Enums.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\294100\3013874066\v1.5\Assemblies\TwitchLib.Client.Enums.dll</HintPath>
     </Reference>
     <Reference Include="TwitchLib.Client.Models">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\ToolkitCore\Assemblies\TwitchLib.Client.Models.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\294100\3013874066\v1.5\Assemblies\TwitchLib.Client.Models.dll</HintPath>
     </Reference>
     <Reference Include="TwitchLib.Communication">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\Mods\ToolkitCore\Assemblies\TwitchLib.Communication.dll</HintPath>
+      <HintPath>C:\Program Files (x86)\Steam\steamapps\workshop\content\294100\3013874066\v1.5\Assemblies\TwitchLib.Communication.dll</HintPath>
     </Reference>
   </ItemGroup>
 </Project>

--- a/TwitchToolkit/TwitchToolkit/CommandsHandler.cs
+++ b/TwitchToolkit/TwitchToolkit/CommandsHandler.cs
@@ -31,26 +31,38 @@ public static class CommandsHandler
 		Command commandDef = DefDatabase<Command>.AllDefs.ToList().Find((Command s) => twitchMessage.Message.StartsWith("!" + s.command));
 		if (commandDef != null)
 		{
-			bool runCommand = true;
-			if (commandDef.requiresMod && !viewer.mod && viewer.username.ToLower() != ToolkitSettings.Channel.ToLower())
-			{
-				runCommand = false;
-            }
-			if (commandDef.requiresAdmin && twitchMessage.Username.ToLower() != ToolkitSettings.Channel.ToLower())
-			{
-				runCommand = false;
+            bool runCommand = true;
 
+            if (commandDef.requiresMod && !viewer.mod && viewer.username.ToLower() != ToolkitSettings.Channel.ToLower())
+            {
+                Log.Message($"Command '{commandDef.command}' blocked: requiresMod=true, but viewer '{viewer.username}' is not a mod and not the channel owner.");
+                runCommand = false;
             }
+
+            if (commandDef.requiresAdmin && twitchMessage.Username.ToLower() != ToolkitSettings.Channel.ToLower())
+            {
+                Log.Message($"Command '{commandDef.command}' blocked: requiresAdmin=true, but '{twitchMessage.Username}' is not the channel owner.");
+                runCommand = false;
+            }
+
             if (!commandDef.enabled)
-			{
-				runCommand = false;
+            {
+                Log.Message($"Command '{commandDef.command}' blocked: command is disabled.");
+                runCommand = false;
             }
+
             if (runCommand)
-			{
+            {
+                Log.Message($"Running command '{commandDef.command}' for user '{twitchMessage.Username}'.");
                 commandDef.RunCommand(twitchMessage);
-			}
-		}
-	}
+            }
+            else
+            {
+                Log.Message($"Command '{commandDef.command}' was not run due to failed permission or disabled flag.");
+            }
+
+        }
+    }
 
 	public static bool SendToChatroom(ChatMessage msg)
 	{

--- a/TwitchToolkit/TwitchToolkit/Ticker.cs
+++ b/TwitchToolkit/TwitchToolkit/Ticker.cs
@@ -166,7 +166,7 @@ public class Ticker : Thing
 			{
 				_lastCoinReward = time;
 			}
-			else if (ToolkitSettings.EarningCoins && time - _lastCoinReward >= ToolkitSettings.CoinInterval && Viewers.jsonallviewers != null)
+			else if (ToolkitSettings.EarningCoins && time - _lastCoinReward >= ToolkitSettings.CoinInterval && Viewers.All != null)
 			{
 				_lastCoinReward = time;
 				Viewers.AwardViewersCoins();
@@ -179,7 +179,6 @@ public class Ticker : Thing
 			{
 				_lastMinute = time;
 				Toolkit.JobManager.CheckAllJobs();
-				Viewers.RefreshViewers();
 			}
 		}
 		catch (Exception ex)

--- a/TwitchToolkit/TwitchToolkit/Viewers.cs
+++ b/TwitchToolkit/TwitchToolkit/Viewers.cs
@@ -1,276 +1,164 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using SimpleJSON;
 using ToolkitCore;
 using TwitchToolkit.Store;
 using TwitchToolkit.Utilities;
-using TwitchToolkitDev;
 using Verse;
 
 namespace TwitchToolkit;
 
-public static class Viewers
-{
-	public static string jsonallviewers;
+public static class Viewers {
+    public static List<Viewer> All = new List<Viewer>();
 
-	public static List<Viewer> All = new List<Viewer>();
+    public static void AwardViewersCoins(int setamount = 0)
+    {
+        List<string> usernames = GetActiveViewerUsernames();
+        if (usernames == null)
+        {
+            return;
+        }
 
-	public static void AwardViewersCoins(int setamount = 0)
-	{
-		List<string> usernames = ParseViewersFromJsonAndFindActiveViewers();
-		if (usernames == null)
-		{
-			return;
-		}
-		foreach (string username in usernames)
-		{
-			Viewer viewer = GetViewer(username);
-			if (viewer.IsBanned)
-			{
-				continue;
-			}
-			if (setamount > 0)
-			{
-				viewer.GiveViewerCoins(setamount);
-				continue;
-			}
-			int baseCoins = ToolkitSettings.CoinAmount;
-			float baseMultiplier = (float)viewer.GetViewerKarma() / 100f;
-			if (viewer.IsSub)
-			{
-				baseCoins += ToolkitSettings.SubscriberExtraCoins;
-				baseMultiplier *= ToolkitSettings.SubscriberCoinMultiplier;
-			}
-			else if (viewer.IsVIP)
-			{
-				baseCoins += ToolkitSettings.VIPExtraCoins;
-				baseMultiplier *= ToolkitSettings.VIPCoinMultiplier;
-			}
-			else if (viewer.mod)
-			{
-				baseCoins += ToolkitSettings.ModExtraCoins;
-				baseMultiplier *= ToolkitSettings.ModCoinMultiplier;
-			}
-			int minutesSinceViewerWasActive = TimeHelper.MinutesElapsed(viewer.last_seen);
-			if (ToolkitSettings.ChatReqsForCoins)
-			{
-				if (minutesSinceViewerWasActive > ToolkitSettings.TimeBeforeHalfCoins)
-				{
-					baseMultiplier *= 0.5f;
-				}
-				if (minutesSinceViewerWasActive > ToolkitSettings.TimeBeforeNoCoins)
-				{
-					baseMultiplier *= 0f;
-				}
-			}
-			double coinsToReward = (double)baseCoins * (double)baseMultiplier;
-			Store_Logger.LogString($"{viewer.username} gets {baseCoins} * {baseMultiplier} coins, total {(int)Math.Ceiling(coinsToReward)}");
-			viewer.GiveViewerCoins((int)Math.Ceiling(coinsToReward));
-		}
-	}
+        foreach (string username in usernames)
+        {
+            Viewer viewer = GetViewer(username);
+            if (viewer.IsBanned)
+                continue;
 
-	public static void GiveAllViewersCoins(int amount, List<Viewer> viewers = null)
-	{
-		if (viewers != null)
-		{
-			foreach (Viewer viewer2 in viewers)
-			{
-				viewer2.GiveViewerCoins(amount);
-			}
-			return;
-		}
-		List<string> usernames = ParseViewersFromJsonAndFindActiveViewers();
-		if (usernames == null)
-		{
-			return;
-		}
-		foreach (string username in usernames)
-		{
-			Viewer viewer = GetViewer(username);
-			if (viewer != null && viewer.GetViewerKarma() > 1)
-			{
-				viewer.GiveViewerCoins(amount);
-			}
-		}
-	}
+            if (setamount > 0)
+            {
+                viewer.GiveViewerCoins(setamount);
+                continue;
+            }
 
-	public static void SetAllViewersCoins(int amount, List<Viewer> viewers = null)
-	{
-		if (viewers != null)
-		{
-			foreach (Viewer viewer in viewers)
-			{
-				viewer.SetViewerCoins(amount);
-			}
-			return;
-		}
-		if (All == null)
-		{
-			return;
-		}
-		foreach (Viewer item in All)
-		{
-			item?.SetViewerCoins(amount);
-		}
-	}
+            int baseCoins = ToolkitSettings.CoinAmount;
+            float baseMultiplier = (float)viewer.GetViewerKarma() / 100f;
 
-	public static void GiveAllViewersKarma(int amount, List<Viewer> viewers = null)
-	{
-		if (viewers != null)
-		{
-			foreach (Viewer viewer2 in viewers)
-			{
-				viewer2.SetViewerKarma(Math.Min(ToolkitSettings.KarmaCap, viewer2.GetViewerKarma() + amount));
-			}
-			return;
-		}
-		List<string> usernames = ParseViewersFromJsonAndFindActiveViewers();
-		if (usernames == null)
-		{
-			return;
-		}
-		foreach (string username in usernames)
-		{
-			Viewer viewer = GetViewer(username);
-			if (viewer != null && viewer.GetViewerKarma() > 1)
-			{
-				viewer.SetViewerKarma(Math.Min(ToolkitSettings.KarmaCap, viewer.GetViewerKarma() + amount));
-			}
-		}
-	}
+            if (viewer.IsSub)
+            {
+                baseCoins += ToolkitSettings.SubscriberExtraCoins;
+                baseMultiplier *= ToolkitSettings.SubscriberCoinMultiplier;
+            }
+            else if (viewer.IsVIP)
+            {
+                baseCoins += ToolkitSettings.VIPExtraCoins;
+                baseMultiplier *= ToolkitSettings.VIPCoinMultiplier;
+            }
+            else if (viewer.mod)
+            {
+                baseCoins += ToolkitSettings.ModExtraCoins;
+                baseMultiplier *= ToolkitSettings.ModCoinMultiplier;
+            }
 
-	public static void TakeAllViewersKarma(int amount, List<Viewer> viewers = null)
-	{
-		if (viewers != null)
-		{
-			foreach (Viewer viewer2 in viewers)
-			{
-				viewer2.SetViewerKarma(Math.Max(0, viewer2.GetViewerKarma() - amount));
-			}
-			return;
-		}
-		if (All == null)
-		{
-			return;
-		}
-		foreach (Viewer viewer in All)
-		{
-			viewer?.SetViewerKarma(Math.Max(0, viewer.GetViewerKarma() - amount));
-		}
-	}
+            int minutesSinceActive = TimeHelper.MinutesElapsed(viewer.last_seen);
+            if (ToolkitSettings.ChatReqsForCoins)
+            {
+                if (minutesSinceActive > ToolkitSettings.TimeBeforeHalfCoins)
+                    baseMultiplier *= 0.5f;
+                if (minutesSinceActive > ToolkitSettings.TimeBeforeNoCoins)
+                    baseMultiplier *= 0f;
+            }
 
-	public static void SetAllViewersKarma(int amount, List<Viewer> viewers = null)
-	{
-		if (viewers != null)
-		{
-			foreach (Viewer viewer in viewers)
-			{
-				viewer.SetViewerKarma(amount);
-			}
-			return;
-		}
-		if (All == null)
-		{
-			return;
-		}
-		foreach (Viewer item in All)
-		{
-			item?.SetViewerKarma(amount);
-		}
-	}
+            double coinsToReward = baseCoins * baseMultiplier;
+            Store_Logger.LogString($"{viewer.username} gets {baseCoins} * {baseMultiplier} coins, total {(int)Math.Ceiling(coinsToReward)}");
+            viewer.GiveViewerCoins((int)Math.Ceiling(coinsToReward));
+        }
+    }
 
-	public static List<string> ParseViewersFromJsonAndFindActiveViewers()
-	{
-		List<string> usernames = new List<string>();
-		string json = jsonallviewers;
-		if (GenText.NullOrEmpty(json))
-		{
-			return null;
-		}
-		JSONNode parsed = JSON.Parse(json);
-		List<JSONArray> groups = new List<JSONArray>();
-		groups.Add(parsed["chatters"]["moderators"].AsArray);
-		groups.Add(parsed["chatters"]["staff"].AsArray);
-		groups.Add(parsed["chatters"]["admins"].AsArray);
-		groups.Add(parsed["chatters"]["global_mods"].AsArray);
-		groups.Add(parsed["chatters"]["viewers"].AsArray);
-		groups.Add(parsed["chatters"]["vips"].AsArray);
-		foreach (JSONArray group in groups)
-		{
-			JSONNode.Enumerator enumerator2 = group.GetEnumerator();
-			while (enumerator2.MoveNext())
-			{
-				JSONNode username = enumerator2.Current;
-				string usernameconvert = username.ToString();
-				usernameconvert = usernameconvert.Remove(0, 1);
-				usernameconvert = usernameconvert.Remove(usernameconvert.Length - 1, 1);
-				usernames.Add(usernameconvert);
-			}
-		}
-		foreach (Viewer viewer in All.Where(delegate(Viewer s)
-		{
-			_ = s.last_seen;
-			return TimeHelper.MinutesElapsed(s.last_seen) <= ToolkitSettings.TimeBeforeHalfCoins;
-		}))
-		{
-			if (!usernames.Contains(viewer.username))
-			{
-				Helper.Log("Viewer " + viewer.username + " added to active viewers through chat participation but not in chatter list.");
-				usernames.Add(viewer.username);
-			}
-		}
-		return usernames;
-	}
+    public static void GiveAllViewersCoins(int amount, List<Viewer> viewers = null)
+    {
+        var targetList = viewers ?? All;
+        foreach (Viewer viewer in targetList)
+        {
+            if (viewer.GetViewerKarma() > 1)
+                viewer.GiveViewerCoins(amount);
+        }
+    }
 
-	public static bool SaveUsernamesFromJsonResponse(RequestState request)
-	{
-		Helper.Log("Saving Usernames From Json Response");
-		jsonallviewers = request.jsonString;
-		return true;
-	}
+    public static void SetAllViewersCoins(int amount, List<Viewer> viewers = null)
+    {
+        var targetList = viewers ?? All;
+        foreach (Viewer viewer in targetList)
+        {
+            viewer?.SetViewerCoins(amount);
+        }
+    }
 
-	public static void ResetViewers()
-	{
-		All = new List<Viewer>();
-	}
+    public static void GiveAllViewersKarma(int amount, List<Viewer> viewers = null)
+    {
+        var targetList = viewers ?? All;
+        foreach (Viewer viewer in targetList)
+        {
+            if (viewer.GetViewerKarma() > 1)
+                viewer.SetViewerKarma(Math.Min(ToolkitSettings.KarmaCap, viewer.GetViewerKarma() + amount));
+        }
+    }
 
-	public static Viewer GetViewer(string user)
-	{
-		Viewer viewer = All.Find((Viewer x) => x.username == user.ToLower());
-		if (viewer == null)
-		{
-			viewer = new Viewer(user);
-			viewer.SetViewerCoins(ToolkitSettings.StartingBalance);
-			viewer.karma = ToolkitSettings.StartingKarma;
-		}
-		return viewer;
-	}
+    public static void TakeAllViewersKarma(int amount, List<Viewer> viewers = null)
+    {
+        var targetList = viewers ?? All;
+        foreach (Viewer viewer in targetList)
+        {
+            viewer?.SetViewerKarma(Math.Max(0, viewer.GetViewerKarma() - amount));
+        }
+    }
 
-	public static Viewer GetViewerById(int id)
-	{
-		return All.Find((Viewer s) => s.id == id);
-	}
+    public static void SetAllViewersKarma(int amount, List<Viewer> viewers = null)
+    {
+        var targetList = viewers ?? All;
+        foreach (Viewer viewer in targetList)
+        {
+            viewer?.SetViewerKarma(amount);
+        }
+    }
 
-	public static void RefreshViewers()
-	{
-		Helper.Log("reshing Viewers");
-		WebRequest_BeginGetResponse.Main("https://tmi.twitch.tv/group/user/" + ToolkitCoreSettings.channel_username.ToLower() + "/chatters", SaveUsernamesFromJsonResponse);
-	}
+    public static List<string> GetActiveViewerUsernames()
+    {
+        return All
+            .Where(v => TimeHelper.MinutesElapsed(v.last_seen) <= ToolkitSettings.TimeBeforeHalfCoins)
+            .Select(v => v.username)
+            .ToList();
+    }
 
-	public static void ResetViewersCoins()
-	{
-		foreach (Viewer viewer in All)
-		{
-			viewer.coins = ToolkitSettings.StartingBalance;
-		}
-	}
+    public static void ResetViewers()
+    {
+        All = new List<Viewer>();
+    }
 
-	public static void ResetViewersKarma()
-	{
-		foreach (Viewer viewer in All)
-		{
-			viewer.karma = ToolkitSettings.StartingKarma;
-		}
-	}
+    public static Viewer GetViewer(string user)
+    {
+        var lowerUser = user.ToLower();
+        Viewer viewer = All.Find(x => x.username == lowerUser);
+        if (viewer == null)
+        {
+            viewer = new Viewer(lowerUser)
+            {
+                karma = ToolkitSettings.StartingKarma
+            };
+            viewer.SetViewerCoins(ToolkitSettings.StartingBalance);
+            All.Add(viewer);
+        }
+        return viewer;
+    }
+
+    public static Viewer GetViewerById(int id)
+    {
+        return All.Find(s => s.id == id);
+    }
+
+    public static void ResetViewersCoins()
+    {
+        foreach (Viewer viewer in All)
+        {
+            viewer.coins = ToolkitSettings.StartingBalance;
+        }
+    }
+
+    public static void ResetViewersKarma()
+    {
+        foreach (Viewer viewer in All)
+        {
+            viewer.karma = ToolkitSettings.StartingKarma;
+        }
+    }
 }


### PR DESCRIPTION
The viewer list is now sourced directly from Viewers.All, which is populated when users send chat messages. This removes the dependency on the legacy Twitch API Chatters endpoint, which has been deprecated in favor of a new OAuth + Client ID flow. That flow is not currently supported by ToolkitCore, and this change ensures continued functionality without requiring external API calls.

Note: Viewers are not removed when they leave chat, this list reflects only those who have participated.